### PR TITLE
おつりがゼロの場合のコメントを追加

### DIFF
--- a/bitcoin_transfer/spend_your_coin.md
+++ b/bitcoin_transfer/spend_your_coin.md
@@ -113,7 +113,7 @@ TxOut hallOfTheMakersTxOut = new TxOut()
     ScriptPubKey = hallOfTheMakersAddress.ScriptPubKey
 };
 
-// おつり 自分に戻す
+// 自分に戻す分 (おつり)
 TxOut changeBackTxOut = new TxOut()
 {
     Value = new Money((decimal)0.4999, MoneyUnit.BTC),

--- a/bitcoin_transfer/spend_your_coin.md
+++ b/bitcoin_transfer/spend_your_coin.md
@@ -102,7 +102,6 @@ var hallOfTheMakersAddress = BitcoinAddress.Create("mzp4No5cmCXjZUpf112B1XWsvWBf
 もし **1BTC** を伴う **トランザクションインプット** から **0.5BTC** を使いたいとしても、確実にすべてのコインを使い切らなければならない！  
 図解が以下に示すとおり、**トランザクションアウトプット** が **0.5** BTCを成功者の殿堂に、そしてあなたに**0.4999**BTCを戻すように仕分けている。  
 残りの **0.0001BTC** はどうなったのだろう？これはマイナーの手数料となっていて、彼らがこのトランザクションを次のブロックに含めるためのインセンティブとなっているのであった。
-*訳注：おつり（changeBackTxOut）がゼロの場合は changeBackTxOut をトランザクションには追加する必要はない。追加するとエラーとなる。*
 
 ![](../assets/SpendTx.png)
 
@@ -122,6 +121,8 @@ TxOut changeBackTxOut = new TxOut()
 transaction.Outputs.Add(hallOfTheMakersTxOut);
 transaction.Outputs.Add(changeBackTxOut);
 ```
+
+*訳注：おつり（changeBackTxOut）がゼロの場合は changeBackTxOut をトランザクションには追加する必要はない。追加するとエラーとなる。*
 
 ここでコードの微調整をしてみる。  
 以下のリンクから、この章のサンプルコードで使っているビットコインアドレスをブロックエクスプローラーでチェックできる。（TestNetのアドレスを使っているが。）

--- a/bitcoin_transfer/spend_your_coin.md
+++ b/bitcoin_transfer/spend_your_coin.md
@@ -124,7 +124,7 @@ transaction.Outputs.Add(hallOfTheMakersTxOut);
 transaction.Outputs.Add(changeBackTxOut);
 ```
 
-*訳注：おつり（changeBackTxOut）がゼロの場合は changeBackTxOut をトランザクションには追加する必要はない。数量がゼロのTxOutはトランザクション実行時にエラーとなる。*
+*訳注：自分に戻す分 (おつり)がゼロの場合は、その TxOut(changeBackTxOut) をトランザクションに追加する必要はない。数量がゼロのTxOutはトランザクション実行時にエラーとなる。*
 
 ここでコードの微調整をしてみる。  
 以下のリンクから、この章のサンプルコードで使っているビットコインアドレスをブロックエクスプローラーでチェックできる。（TestNetのアドレスを使っているが。）

--- a/bitcoin_transfer/spend_your_coin.md
+++ b/bitcoin_transfer/spend_your_coin.md
@@ -106,12 +106,14 @@ var hallOfTheMakersAddress = BitcoinAddress.Create("mzp4No5cmCXjZUpf112B1XWsvWBf
 ![](../assets/SpendTx.png)
 
 ```cs
+// 成功者の殿堂に送る分
 TxOut hallOfTheMakersTxOut = new TxOut()
 {
     Value = new Money((decimal)0.5, MoneyUnit.BTC),
     ScriptPubKey = hallOfTheMakersAddress.ScriptPubKey
 };
 
+// おつり 自分に戻す
 TxOut changeBackTxOut = new TxOut()
 {
     Value = new Money((decimal)0.4999, MoneyUnit.BTC),

--- a/bitcoin_transfer/spend_your_coin.md
+++ b/bitcoin_transfer/spend_your_coin.md
@@ -142,6 +142,7 @@ Money changeBackAmount = txInAmount - hallOfTheMakersAmount - minerFee;
 ```
 
 計算した値をトランザクションアウトプットに追加する。
+訳注：changeBackAmount がゼロの場合は changeBackTxOut をトランザクションには追加する必要はない。追加するとエラーとなる。
 
 ```cs
 TxOut hallOfTheMakersTxOut = new TxOut()

--- a/bitcoin_transfer/spend_your_coin.md
+++ b/bitcoin_transfer/spend_your_coin.md
@@ -122,7 +122,7 @@ transaction.Outputs.Add(hallOfTheMakersTxOut);
 transaction.Outputs.Add(changeBackTxOut);
 ```
 
-*訳注：おつり（changeBackTxOut）がゼロの場合は changeBackTxOut をトランザクションには追加する必要はない。追加するとエラーとなる。*
+*訳注：おつり（changeBackTxOut）がゼロの場合は changeBackTxOut をトランザクションには追加する必要はない。数量がゼロのTxOutはトランザクション実行時にエラーとなる。*
 
 ここでコードの微調整をしてみる。  
 以下のリンクから、この章のサンプルコードで使っているビットコインアドレスをブロックエクスプローラーでチェックできる。（TestNetのアドレスを使っているが。）

--- a/bitcoin_transfer/spend_your_coin.md
+++ b/bitcoin_transfer/spend_your_coin.md
@@ -124,7 +124,7 @@ transaction.Outputs.Add(hallOfTheMakersTxOut);
 transaction.Outputs.Add(changeBackTxOut);
 ```
 
-*訳注：自分に戻す分 (おつり)がゼロの場合は、その TxOut(changeBackTxOut) をトランザクションに追加する必要はない。数量がゼロのTxOutはトランザクション実行時にエラーとなる。*
+*訳注：自分に戻す分 (おつり)がゼロの場合は、その TxOut (上記では changeBackTxOut) をトランザクションに追加する必要はない。数量がゼロのTxOutはトランザクション実行時にエラーとなる。*
 
 ここでコードの微調整をしてみる。  
 以下のリンクから、この章のサンプルコードで使っているビットコインアドレスをブロックエクスプローラーでチェックできる。（TestNetのアドレスを使っているが。）

--- a/bitcoin_transfer/spend_your_coin.md
+++ b/bitcoin_transfer/spend_your_coin.md
@@ -102,6 +102,7 @@ var hallOfTheMakersAddress = BitcoinAddress.Create("mzp4No5cmCXjZUpf112B1XWsvWBf
 もし **1BTC** を伴う **トランザクションインプット** から **0.5BTC** を使いたいとしても、確実にすべてのコインを使い切らなければならない！  
 図解が以下に示すとおり、**トランザクションアウトプット** が **0.5** BTCを成功者の殿堂に、そしてあなたに**0.4999**BTCを戻すように仕分けている。  
 残りの **0.0001BTC** はどうなったのだろう？これはマイナーの手数料となっていて、彼らがこのトランザクションを次のブロックに含めるためのインセンティブとなっているのであった。
+*訳注：おつり（changeBackTxOut）がゼロの場合は changeBackTxOut をトランザクションには追加する必要はない。追加するとエラーとなる。*
 
 ![](../assets/SpendTx.png)
 
@@ -142,7 +143,6 @@ Money changeBackAmount = txInAmount - hallOfTheMakersAmount - minerFee;
 ```
 
 計算した値をトランザクションアウトプットに追加する。
-訳注：changeBackAmount がゼロの場合は changeBackTxOut をトランザクションには追加する必要はない。追加するとエラーとなる。
 
 ```cs
 TxOut hallOfTheMakersTxOut = new TxOut()


### PR DESCRIPTION
TxOut の Valueをゼロとしてトランザクションを流すとエラーが返りますが、この件に関しての説明を追加しました。Mainnetで実践する場合、間違えて全額を使ってしまわないように自分のメインウオレットから寄付分の金額だけ一時的に別のビットコインアドレスに移し、そこから成功者の殿堂にすべて送るパターンの人がいると思います。その時、おつりがゼロのTxOutを追加する必要があるのか？私自身、これで少し悩みましたので。。。